### PR TITLE
Add Paper 26.1.2 (Java 25) support

### DIFF
--- a/TempFly/dependency-reduced-pom.xml
+++ b/TempFly/dependency-reduced-pom.xml
@@ -66,6 +66,10 @@
       <url>https://repo.bg-software.com/repository/api/</url>
     </repository>
     <repository>
+      <id>papermc</id>
+      <url>https://repo.papermc.io/repository/maven-public/</url>
+    </repository>
+    <repository>
       <id>spigot-repo</id>
       <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
     </repository>
@@ -90,9 +94,9 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.spigotmc</groupId>
-      <artifactId>spigot-api</artifactId>
-      <version>1.21.8-R0.1-SNAPSHOT</version>
+      <groupId>io.papermc.paper</groupId>
+      <artifactId>paper-api</artifactId>
+      <version>26.1.2.build.69-stable</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/TempFly/pom.xml
+++ b/TempFly/pom.xml
@@ -70,6 +70,11 @@
         </repository>
 
         <repository>
+            <id>papermc</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
+        </repository>
+
+        <repository>
             <id>spigot-repo</id>
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
@@ -111,30 +116,11 @@
             <version>5.2.1</version>
         </dependency>
 
-		<dependency>
-			<groupId>org.xerial</groupId>
-			<artifactId>sqlite-jdbc</artifactId>
-			<version>3.45.1.0</version>
-		</dependency>
-
-        <!-- Bukkit / Spigot / Plugins -->
+        <!-- Bukkit / Paper / Plugins -->
         <dependency>
-            <groupId>org.mongodb</groupId>
-            <artifactId>mongodb-driver-sync</artifactId>
-            <version>5.2.1</version>
-        </dependency>
-
-		<dependency>
-			<groupId>org.xerial</groupId>
-			<artifactId>sqlite-jdbc</artifactId>
-			<version>3.45.1.0</version>
-		</dependency>
-
-        <!-- Bukkit / Spigot / Plugins -->
-        <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot-api</artifactId>
-            <version>1.21.8-R0.1-SNAPSHOT</version>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>26.1.2.build.69-stable</version>
             <scope>provided</scope>
         </dependency>
 

--- a/TempFly/resources/plugin.yml
+++ b/TempFly/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: TempFly
 main: com.moneybags.tempfly.TempFly
 softdepend: [Essentials, PlaceholderAPI, Vault, WorldGuard, WorldEdit]
-api-version: 1.13
+api-version: '26.1'
 version: 3.2.0
 commands:
     tempfly:

--- a/TempFly/src/com/moneybags/tempfly/aesthetic/ActionBarAPI.java
+++ b/TempFly/src/com/moneybags/tempfly/aesthetic/ActionBarAPI.java
@@ -3,18 +3,18 @@ package com.moneybags.tempfly.aesthetic;
 import com.moneybags.tempfly.aesthetic.actionbar.ActionBar;
 import com.moneybags.tempfly.aesthetic.actionbar.LegacyActionBar;
 import com.moneybags.tempfly.aesthetic.actionbar.ModernActionBar;
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
 import com.moneybags.tempfly.TempFly;
+import com.moneybags.tempfly.util.U;
 
 public class ActionBarAPI {
-	
+
 	private static ActionBar actionBar;
-    
+
     public static void initialize(TempFly tempfly) {
         // Check if we're on 1.12 or above
-    	  if (Bukkit.getServer().getVersion().matches(".*1\\.(?!10|11)\\d{2,}.*")) {
+    	  if (U.isModernServer()) {
     	      actionBar = new ModernActionBar(tempfly);
         } else {
     	      actionBar = new LegacyActionBar(tempfly);

--- a/TempFly/src/com/moneybags/tempfly/aesthetic/TitleAPI.java
+++ b/TempFly/src/com/moneybags/tempfly/aesthetic/TitleAPI.java
@@ -1,19 +1,19 @@
 package com.moneybags.tempfly.aesthetic;
 
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
 import com.moneybags.tempfly.TempFly;
 import com.moneybags.tempfly.aesthetic.title.LegacyTitle;
 import com.moneybags.tempfly.aesthetic.title.ModernTitle;
 import com.moneybags.tempfly.aesthetic.title.Title;
+import com.moneybags.tempfly.util.U;
 
 public class TitleAPI {
 
 	private static Title title;
-	
+
     public static void initialize(TempFly tempfly) {
-    	  if (Bukkit.getServer().getVersion().matches(".*1\\.(?!10|11)\\d{2,}.*")) {
+    	  if (U.isModernServer()) {
     	      title = new ModernTitle();
         } else {
     	      title = new LegacyTitle();

--- a/TempFly/src/com/moneybags/tempfly/aesthetic/particle/Particles.java
+++ b/TempFly/src/com/moneybags/tempfly/aesthetic/particle/Particles.java
@@ -33,15 +33,9 @@ public class Particles {
 	}
 	
 	public static boolean oldParticles() {
-		String version = Bukkit.getBukkitVersion(); // Obtain the current version number
-		String[] parts = version.split(".");
-		try {
-			int major = Integer.parseInt(parts[0]);
-			int minor = Integer.parseInt(parts[1]);
-			return major == 1 && minor <= 12;
-		} catch (Exception e) {
-			return true;
-		}
+		// Modern servers (1.13+ / calendar versions) use the spawnParticle API;
+		// only pre-1.13 needs the legacy Effect-based path.
+		return !com.moneybags.tempfly.util.U.isModernServer();
 	}
 	
 	public static void play(Location loc, String s) {

--- a/TempFly/src/com/moneybags/tempfly/command/player/CmdDisplay.java
+++ b/TempFly/src/com/moneybags/tempfly/command/player/CmdDisplay.java
@@ -81,7 +81,7 @@ public class CmdDisplay extends TempFlyCommand {
         // Before running check, let's include a failsafe in the event this is null. This check will
         // use TempFly's default setting for Display State (true) as the fallback.
         if (current == null) {
-          current = true
+          current = true;
         }
         newState = !current;
         Console.debug("TF--| CmdDisplay: Toggling self display state to " + newState);

--- a/TempFly/src/com/moneybags/tempfly/util/U.java
+++ b/TempFly/src/com/moneybags/tempfly/util/U.java
@@ -23,6 +23,25 @@ public class U {
 	public static void command(String s) {
 		Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), s);
 	}
+
+	private static final Pattern VERSION_PATTERN = Pattern.compile("(\\d+)\\.(\\d+)");
+
+	/**
+	 * Determines whether the running server uses the modern (1.12+) Bukkit API.
+	 * Handles both the legacy "1.x.y" scheme and the calendar-based scheme
+	 * introduced in 2026 (e.g. "26.1.2"). Anything older than 1.12 is treated
+	 * as legacy. Defaults to modern when the version cannot be parsed.
+	 */
+	public static boolean isModernServer() {
+		java.util.regex.Matcher m = VERSION_PATTERN.matcher(Bukkit.getBukkitVersion());
+		if (!m.find()) {
+			return true;
+		}
+		int major = Integer.parseInt(m.group(1));
+		int minor = Integer.parseInt(m.group(2));
+		// Calendar versions (>= year 2026) and any 1.12+ release are modern.
+		return major > 1 || (major == 1 && minor >= 12);
+	}
 	
 	public static boolean isPlayer(CommandSender s){
 		return s instanceof Player;

--- a/TempFly/src/com/moneybags/tempfly/util/data/Files.java
+++ b/TempFly/src/com/moneybags/tempfly/util/data/Files.java
@@ -265,9 +265,8 @@ public class Files {
 		Console.debug("Looking for key '" + key + "' (path: " + fullPath + ") at indent level " + targetIndent);
 
 		// Build the expected parent indents
-		String[] pathParts = fullPath.split("\\.");
 		List<String> pathStack = new ArrayList<>();
-		for (iString part : pathParts) {
+		for (String part : pathParts) {
 			pathStack.add(part);
 		}
 		pathStack.remove(pathStack.size() - 1); // Remove key, we're just getting the parents


### PR DESCRIPTION
Build:
- Switch dependency from spigot-api 1.21.8 to paper-api 26.1.2.build.69-stable and add the PaperMC repository.
- Remove the triplicated mongodb/sqlite dependency declarations.
- plugin.yml api-version bumped 1.13 -> '26.1'.

Note: paper-api 26.1.2 is Java 25 bytecode, so the server (and build toolchain) must run on Java 25.

Runtime correctness:
- Add U.isModernServer() and route ActionBarAPI, TitleAPI and Particles through it. The old regex (".*1\.(?!10|11)\d{2,}.*") does not match the new calendar version string "26.1.2", which would have selected the dead legacy NMS reflection paths. Also fixes Particles.oldParticles()'s broken split(".") regex.

Pre-existing compile fixes (source did not compile as-is):
- CmdDisplay.java: missing semicolon.
- Files.java: duplicate 'pathParts' declaration and 'iString' typo.